### PR TITLE
Fixed Loading wad properties instead of jwtenizr.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ token.jwt
 microprofile-config.properties
 jwtenizr-config.json
 cleanup.sh
+/target/

--- a/src/main/java/com/airhacks/jwtenizr/control/Configuration.java
+++ b/src/main/java/com/airhacks/jwtenizr/control/Configuration.java
@@ -16,13 +16,13 @@ public class Configuration {
 
     public String privateKey;
     public String publicKey;
-    public String mpConfiguratioFolder;
+    public String mpConfigurationFolder;
     public String mpConfigIssuer;
 
     private final static String CONFIGURATION_FILE = "jwtenizr-config.json";
 
     protected Configuration() {
-        this.mpConfiguratioFolder = ".";
+        this.mpConfigurationFolder = ".";
         this.mpConfigIssuer = "airhacks";
     }
 
@@ -66,7 +66,7 @@ public class Configuration {
     }
 
     public static String mpConfigurationLocation() {
-        return load().mpConfiguratioFolder;
+        return load().mpConfigurationFolder;
     }
 
     public static String issuer() {

--- a/src/main/java/com/airhacks/jwtenizr/control/Terminal.java
+++ b/src/main/java/com/airhacks/jwtenizr/control/Terminal.java
@@ -49,7 +49,7 @@ public interface Terminal {
     public static void printWelcomeMessage() throws IOException {
         try (InputStream resourceAsStream = App.class.
                 getClassLoader().
-                getResourceAsStream("META-INF/maven/com.airhacks/wad/pom.properties")) {
+                getResourceAsStream("META-INF/maven/com.airhacks/jwtenizr/pom.properties")) {
             if (resourceAsStream == null) {
                 System.out.println("\njwtenizr - unknown version\n");
                 return;


### PR DESCRIPTION
jwtenizr.sh message would always return"jwtenizr unknown version" because wrong properties file was being loaded, also fixed mpConfiguration typo. 